### PR TITLE
Remove the Campaign column from the ES table

### DIFF
--- a/eleanor/hanger/db_comms.py
+++ b/eleanor/hanger/db_comms.py
@@ -110,8 +110,8 @@ def create_es_table(conn, camp, loaded_sp, elements):
     instantiated fof the campaign
     """
 
-    sql_info = "CREATE TABLE IF NOT EXISTS es (uuid VARCHAR(32) PRIMARY KEY, camp \
-        TEXT NOT NULL, ord INTEGER NOT NULL, file INTEGER NOT NULL, run \
+    sql_info = "CREATE TABLE IF NOT EXISTS es (uuid VARCHAR(32) PRIMARY KEY,\
+        ord INTEGER NOT NULL, file INTEGER NOT NULL, run \
         DATE NOT NULL, mineral TEXT NOT NULL,"
 
     sql_run = ",".join([f'"{_}" DOUBLE PRECISION NOT NULL' for _ in

--- a/eleanor/helmsman.py
+++ b/eleanor/helmsman.py
@@ -484,7 +484,7 @@ def mine_6o(camp, date, elements, ss, file, dat, col_names):
         build_dict[_] = temp_s_dict[_]
 
     build_dict['uuid'] = [dat[0]]
-    build_dict['camp'] = [dat[1]]
+    # build_dict['camp'] = [dat[1]]  # Removing the campaign name from the ES table
     build_dict['ord'] = [dat[2]]
     build_dict['file'] = [dat[3]]
     build_dict['run'] = [date]


### PR DESCRIPTION
This PR should not be merged before discussing with @Tucker-Ely. 

I've removed the 'camp' column from the ES table because each campaign has its own DB. This doesn't cause a conflict with Eleanor but it might be difficult to combine with previous data. 

Worth a conversation. See also Issue #60 