### PR TITLE
Allow NULL values in solid solutions columns of ES

### DIFF
--- a/eleanor/hanger/data0_tools.py
+++ b/eleanor/hanger/data0_tools.py
@@ -215,9 +215,10 @@ def determine_loaded_sp(path=''):
         gas = [_.split(' (')[0] for _ in ss_and_gas if '(Gas)' in _]
         ss = [_.split(' (')[1].strip(')(') for _ in ss_and_gas if '(Gas)' not in _]
 
-        sp_names = aq_and_s + gas + list(set(ss))
+        sp_names = aq_and_s + gas
+        ss_names = list(set(ss))
 
-    return sp_names
+    return sp_names, ss_names
 
 def determine_T_P_coverage(data0_dir):
     """

--- a/eleanor/hanger/db_comms.py
+++ b/eleanor/hanger/db_comms.py
@@ -97,7 +97,7 @@ def create_orders_table(conn):
         ON `orders` (`campaign_hash`, `data0_hash`)
     ''')
 
-def create_es_table(conn, camp, loaded_sp, elements):
+def create_es_table(conn, camp, loaded_sp, loaded_ss, elements):
     """
     Initiater equilibrium space (mined from 6o) table on connection 'conn'
     for campaign 'camp_name' with state dimensions 'camp_vs_state' and
@@ -106,8 +106,10 @@ def create_es_table(conn, camp, loaded_sp, elements):
     (3i) as the vs table is, but is instead popuilated with the output (6o)
     total abundences.
 
-    loaded_sp = list of aq, solid,a nd gas species loaded in test.3i
-    instantiated fof the campaign
+    :param conn: the database connection
+    :param camp: the campaign
+    :param loaded_sp: loaded aqueous, solid and gas species
+    :param loaded_ss: loaded solid solution species
     """
 
     sql_info = "CREATE TABLE IF NOT EXISTS es (uuid VARCHAR(32) PRIMARY KEY,\
@@ -130,10 +132,12 @@ def create_es_table(conn, camp, loaded_sp, elements):
     sql_sp = ",".join([f'"{_}" DOUBLE PRECISION NOT NULL' for _ in
                        loaded_sp]) + ','
 
+    sql_ss = ",".join([f'"{_}" DOUBLE PRECISION' for _ in loaded_ss]) + ','
+
     sql_fk = ' FOREIGN KEY(`ord`) REFERENCES `orders`(`id`), \
                FOREIGN KEY(`uuid`) REFERENCES `vs`(`uuid`)'
 
-    parts = [sql_info, sql_run, sql_state, sql_ele, sql_sp, sql_fk]
+    parts = [sql_info, sql_run, sql_state, sql_ele, sql_sp, sql_ss, sql_fk]
     execute_query(conn, ''.join(parts) + ')')
 
 def get_order_number(conn, camp, insert=True):

--- a/eleanor/navigator.py
+++ b/eleanor/navigator.py
@@ -71,7 +71,6 @@ def Navigator(this_campaign, quiet=False):
 
         # Grab non O/H elements and species data from the verbose huffer test.3o files
         elements = determine_ele_set(path="huffer/")
-        # sp_names = determine_loaded_sp(path="huffer/")
 
         # Current order birthday
         date = time.strftime("%Y-%m-%d", time.gmtime())
@@ -146,12 +145,11 @@ def huffer(conn, camp, quiet=False):
         # New VS table based on vs_state and vs_basis
         db_comms.create_vs_table(conn, camp, elements)
 
-        # Determine column names fof ES table
-        # List of loaded aq, solid, and gas species to be appended
-        sp_names = determine_loaded_sp()
+        # Determine column names of the ES table
+        sp_names, ss_names = determine_loaded_sp()
 
         # New ES table based on loaded species.
-        db_comms.create_es_table(conn, camp, sp_names, elements)
+        db_comms.create_es_table(conn, camp, sp_names, ss_names, elements)
 
     if not quiet:
         print('   Huffer complete.\n')


### PR DESCRIPTION
There are certain situations in which solid solutions may not precipitate due to thermodynamic reasons, despite the user requesting that they do. When that happens, EQ6 doesn't write the name of the solid solution to the 6o file in the expected location. The result is NaNs in the pandas dataframe which we use to insert the results into the database. Those NaNs are implicitly converted to NULL (because sqlite3 doesn't understand NaN), and so we run into a constraint error.

To fix this, we simply lift the NOT NULL constraint on the solid solution columns.
